### PR TITLE
Make file uploads async to avoid hanging Moonraker event loop.

### DIFF
--- a/klipper-fsmount.service
+++ b/klipper-fsmount.service
@@ -11,8 +11,8 @@ RestartSec=5
 User=printerpi
 Group=printerpi
 
-ExecStart=/bin/sh -c "mountpoint -q /home/printerpi/printer_data/gcodes || echo 'rockchip' | sshfs -o password_stdin,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3 root@192.168.1.47:/useremain/app/gk/gcodes/ /home/printerpi/printer_data/gcodes"
-ExecStart=/bin/sh -c "mountpoint -q /home/printerpi/mounted_printer_data || echo 'rockchip' | sshfs -o password_stdin,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3 root@192.168.1.47:/userdata/app/gk/printer_data /home/printerpi/mounted_printer_data"
+ExecStart=/bin/sh -c "mountpoint -q /home/printerpi/printer_data/gcodes || echo 'rockchip' | sshfs -o password_stdin,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,ConnectTimeout=2 root@192.168.1.47:/useremain/app/gk/gcodes/ /home/printerpi/printer_data/gcodes"
+ExecStart=/bin/sh -c "mountpoint -q /home/printerpi/mounted_printer_data || echo 'rockchip' | sshfs -o password_stdin,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,ConnectTimeout=2 root@192.168.1.47:/userdata/app/gk/printer_data /home/printerpi/mounted_printer_data"
 
 ExecStop=/bin/sh -c "mountpoint -q /home/printerpi/printer_data/gcodes && umount /userdata/app/gk/printer_data/gcodes"
 ExecStop=/bin/sh -c "mountpoint -q /home/printerpi/mounted_printer_data && umount /home/printerpi/mounted_printer_data"

--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -3,6 +3,7 @@ server.document-root = "/home/printerpi/mainsail"
 server.modules  =  ( "mod_proxy", "mod_rewrite" )
 server.stream-response-body = 2
 server.upload-dirs = ( "/tmp" )
+server.max-workers = 2
 
 index-file.names = ( "index.html" )
 


### PR DESCRIPTION
The current implementation using sshfs can be quite slow with some latency. This hangs the Moonraker event loop making Mainsail disconnect, etc.

These changes ensure that Moonraker is responsive even when a file upload is happening.