### PR TITLE
Fixed double job starts in Moonraker.

### DIFF
--- a/moonraker/kobra.py
+++ b/moonraker/kobra.py
@@ -49,6 +49,9 @@ class Kobra:
                     state = 'printing'
                 if state.lower() == 'onpause':
                     state = 'paused'
+                # Moonraker does an "is not" comparison in job_state.py resulting in double job start events. This ensures the static memory location is returned.
+                if state.lower() == 'printing':
+                    state = 'printing'
 
                 status['print_stats']['state'] = state
 


### PR DESCRIPTION
The Moonraker code is using an `is not` comparison. Because `'printing'` is hard coded for the `'heating'` state this value is now referenced in the stack. When we get a value from the printer directly this is a heap allocated memory value and the `is not` comparison fails. This change ensures that both values come from the stack.

Note that the above has not been properly verified (GDB on Python internals?) and something else could be happening. However, the above makes enough sense to me and fixes the bug. The check should ideally be fixed in Moonraker or alternatively we could stack allocate all state values here.